### PR TITLE
Remove Tonflow from the list of supported wallets

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -82,19 +82,6 @@
     "platforms": ["ios", "android"]
   },
   {
-    "app_name": "tonflow",
-    "name": "TonFlow",
-    "image": "https://tonflow.net/assets/images/tonflow_ico_192.png",
-    "about_url": "https://tonflow.net",
-    "bridge": [
-      {
-        "type": "js",
-        "key": "tonflow"
-      }
-    ],
-    "platforms": ["chrome"]
-  },
-  {
     "app_name": "dewallet",
     "name": "DeWallet",
     "image": "https://app.delabwallet.com/logo_black.png",


### PR DESCRIPTION
The decision was made due to the inactivity of Tonflow, their website https://tonflow.net is no longer operational, and there appears to be no ongoing support or maintenance for the wallet. 

This removal is to ensure that the users have access to reliable and actively supported wallets.