### PR TITLE
Reorder wallets based on activity

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -34,19 +34,6 @@
     "platforms": ["ios", "android", "chrome", "firefox", "macos"]
   },
   {
-    "app_name": "openmask",
-    "name": "OpenMask",
-    "image": "https://raw.githubusercontent.com/OpenProduct/openmask-extension/main/public/openmask-logo-288.png",
-    "about_url": "https://www.openmask.app/",
-    "bridge": [
-      {
-        "type": "js",
-        "key": "openmask"
-      }
-    ],
-    "platforms": ["chrome"]
-  },
-  {
     "app_name": "mytonwallet",
     "name": "MyTonWallet",
     "image": "https://mytonwallet.io/icon-256.png",
@@ -63,6 +50,19 @@
       }
     ],
     "platforms": ["chrome", "windows", "macos", "linux", "ios", "android", "firefox"]
+  },
+  {
+    "app_name": "openmask",
+    "name": "OpenMask",
+    "image": "https://raw.githubusercontent.com/OpenProduct/openmask-extension/main/public/openmask-logo-288.png",
+    "about_url": "https://www.openmask.app/",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "openmask"
+      }
+    ],
+    "platforms": ["chrome"]
   },
   {
     "app_name": "tonhub",


### PR DESCRIPTION
Recent activity trends indicate a shift in usage patterns, with MyTonWallet showing relatively higher user engagement compared to OpenMask.

To reflect these trends and provide the users with the most relevant and actively used wallets first, this PR repositions MyTonWallet ahead of OpenMask in the list.