### PR TITLE
fix: correct universal link for delab wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -93,7 +93,7 @@
   {
     "app_name": "dewallet",
     "name": "DeWallet",
-    "image": "https://de-cdn.delab.team/icons/WalletAvatar.png",
+    "image": "https://raw.githubusercontent.com/delab-team/manifests-images/main/WalletAvatar.png",
     "about_url": "https://delabwallet.com",
     "universal_url": "https://t.me/delabtonbot?attach=wallet",
     "bridge": [

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -95,7 +95,7 @@
     "name": "DeWallet",
     "image": "https://de-cdn.delab.team/icons/WalletAvatar.png",
     "about_url": "https://delabwallet.com",
-    "universal_url": "https://t.me/delabtonbot/wallet?attach=wallet",
+    "universal_url": "https://t.me/delabtonbot?attach=wallet",
     "bridge": [
      
       {

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -95,14 +95,12 @@
     "name": "DeWallet",
     "image": "https://raw.githubusercontent.com/delab-team/manifests-images/main/WalletAvatar.png",
     "about_url": "https://delabwallet.com",
-    "universal_url": "https://t.me/delabtonbot?attach=wallet",
+    "universal_url": "https://t.me/dewallet?attach=wallet",
     "bridge": [
-     
       {
         "type": "sse",
         "url": "https://sse-bridge.delab.team/bridge"
       }
-
     ],
     "platforms": ["ios", "android"]
   },


### PR DESCRIPTION
# Add Delab wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [ ] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](link)

## Integrator contacts
* telegram
* email
* discord
* ...
