### PR TITLE
add Crypto.com DeFi Wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -210,5 +210,20 @@
       "ios",
       "android"
     ]
+  },
+  {
+    "app_name": "cdcTonWallet",
+    "name": "Crypto.com DeFi Wallet",
+    "image": "https://apro-ncw-api-file.crypto.com/wallet/logo",
+    "about_url": "https://crypto.com/defi-wallet",
+    "universal_url": "https://wallet.crypto.com/deeplink/ton-connect",
+    "deepLink": "dfw://",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "cdcTonWallet"
+      }
+    ],
+    "platforms": ["ios", "android", "chrome"]
   }
 ]


### PR DESCRIPTION
# Add Crypto.com DeFi Wallet wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [x] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [x] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](link)

## Integrator contacts
* telegram: wayne_liu_crypto
