### PR TITLE
Change OKX Wallet universal link to okx.com

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -169,12 +169,12 @@
   ],
   "platforms": ["ios", "android", "chrome", "firefox"]
  },
- {
+  {
     "app_name": "okxTonWallet",
     "name": "OKX Wallet",
     "image": "https://static.okx.com/cdn/assets/imgs/247/58E63FEA47A2B7D7.png",
     "about_url": "https://www.okx.com/web3",
-    "universal_url": "https://www.ouxyi.link/ul/uYJPB0",
+    "universal_url": "https://www.okx.com/ul/uYJPB0",
     "bridge": [
       {
         "type": "js",
@@ -187,12 +187,12 @@
     ],
     "platforms": ["chrome", "safari", "firefox", "ios", "android"]
   },
- {
+  {
   "app_name": "okxTonWalletTr",
   "name": "OKX TR Wallet",
   "image": "https://static.okx.com/cdn/assets/imgs/247/587A8296F0BB640F.png",
   "about_url": "https://tr.okx.com/web3",
-  "universal_url": "https://www.ouxyi.link/ul/uYJPB0?entityId=5",
+  "universal_url": "https://tr.okx.com/ul/uYJPB0?entityId=5",
   "bridge": [
       {
         "type": "js",


### PR DESCRIPTION
# Change OKX Wallet universal link to okx.com 

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](link)

## Integrator contacts
* telegram
* email
* discord
* ...
