### PR TITLE
feat: add Bitget Wallet Lite

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -135,7 +135,7 @@
     "name": "Bitget Wallet Lite",
     "image": "https://raw.githubusercontent.com/bitgetwallet/download/main/logo/png/bitget_wallet_lite_logo.png",
     "about_url": "https://web3.bitget.com",
-    "universal_url": "https://t.me/BitgetWallet_TGBot/BGW",
+    "universal_url": "https://t.me/BitgetWallet_TGBot?attach=wallet",
     "bridge": [
       {
         "type": "sse",

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -131,6 +131,20 @@
     "platforms": ["chrome"]
   },
   {
+    "app_name": "bitgetWalletLite",
+    "name": "Bitget Wallet Lite",
+    "image": "https://github.com/bitgetwallet/download/blob/main/logo/png/bitget_wallet_lite_logo.png",
+    "about_url": "https://web3.bitget.com",
+    "universal_url": "https://t.me/BitgetWallet_TGBot/BGW",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "macos", "windows", "linux"]
+  },
+  {
     "app_name": "bitgetTonWallet",
     "name": "Bitget Wallet",
     "image": "https://raw.githubusercontent.com/bitkeepwallet/download/main/logo/png/bitget_wallet_logo_0_gas_fee.png",

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -79,20 +79,6 @@
     "universal_url": "https://bkcode.vip/ton-connect"
   },
   {
-    "app_name": "bitgetWalletLite",
-    "name": "Bitget Wallet Lite",
-    "image": "https://raw.githubusercontent.com/bitgetwallet/download/refs/heads/main/logo/png/bitget_wallet_lite_logo_288.png",
-    "about_url": "https://web3.bitget.com",
-    "universal_url": "https://t.me/BitgetWallet_TGBot?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
-      }
-    ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
-  },
-  {
     "app_name": "binanceWeb3TonWallet",
     "name": "Binance Web3 Wallet",
     "image": "https://public.bnbstatic.com/static/binance-w3w/ton-provider/binancew3w.png",
@@ -336,5 +322,19 @@
       "windows",
       "linux"
     ]
+  },
+  {
+    "app_name": "bitgetWalletLite",
+    "name": "Bitget Wallet Lite",
+    "image": "https://raw.githubusercontent.com/bitgetwallet/download/refs/heads/main/logo/png/bitget_wallet_lite_logo_288.png",
+    "about_url": "https://web3.bitget.com",
+    "universal_url": "https://t.me/BitgetWallet_TGBot?attach=wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "macos", "windows", "linux"]
   }
 ]

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -133,7 +133,7 @@
   {
     "app_name": "bitgetWalletLite",
     "name": "Bitget Wallet Lite",
-    "image": "https://github.com/bitgetwallet/download/blob/main/logo/png/bitget_wallet_lite_logo.png",
+    "image": "https://raw.githubusercontent.com/bitgetwallet/download/main/logo/png/bitget_wallet_lite_logo.png",
     "about_url": "https://web3.bitget.com",
     "universal_url": "https://t.me/BitgetWallet_TGBot/BGW",
     "bridge": [

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -81,7 +81,7 @@
   {
     "app_name": "bitgetWalletLite",
     "name": "Bitget Wallet Lite",
-    "image": "https://raw.githubusercontent.com/bitgetwallet/download/main/logo/png/bitget_wallet_lite_logo.png",
+    "image": "https://raw.githubusercontent.com/bitgetwallet/download/refs/heads/main/logo/png/bitget_wallet_lite_logo_288.png",
     "about_url": "https://web3.bitget.com",
     "universal_url": "https://t.me/BitgetWallet_TGBot?attach=wallet",
     "bridge": [


### PR DESCRIPTION
# Add Bitget Wallet Lite

## Supports
- [ ] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [x] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests

## Integrator contacts
