### PR TITLE
feat: temporary remove bybit wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -220,25 +220,6 @@
     "platforms": ["ios", "android", "macos", "windows", "linux"]
   },
   {
-    "app_name": "bybitTonWallet",
-    "name": "Bybit Wallet",
-    "image": "https://s1.bycsi.com/bybit/deadpool/image-ac5bf003d25c4ae0bd21f3725694a850.png",
-    "about_url": "https://www.bybit.com/web3",
-    "universal_url": "https://app.bybit.com/ton-connect",
-    "deepLink": "bybitapp://",
-    "bridge": [
-      {
-        "type": "js",
-        "key": "bybitTonWallet"
-      },
-      {
-        "type": "sse",
-        "url": "https://api-node.bybit.com/spot/api/web3/bridge/ton/bridge"
-      }
-    ],
-    "platforms": ["ios", "android", "chrome"]
-  },
-  {
     "app_name": "GateWallet",
     "name": "GateWallet",
     "image": "https://img.gatedataimg.com/prd-ordinal-imgs/036f07bb8730716e/gateio-0925.png",


### PR DESCRIPTION
The wallet has been temporarily removed due to issues with the logo link.