### PR TITLE
Remove `mode=compact` from universal links due to TON Connect update

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -4,7 +4,7 @@
     "name": "Wallet",
     "image": "https://wallet.tg/images/logo-288.png",
     "about_url": "https://wallet.tg/",
-    "universal_url": "https://t.me/wallet?attach=wallet&mode=compact",
+    "universal_url": "https://t.me/wallet?attach=wallet",
     "bridge": [
       {
         "type": "sse",


### PR DESCRIPTION
When `mode=compact` is placed before `startapp` parameter in universal links, Telegram doesn't read the `startapp` value correctly. This breaks authorization and transaction signing. 

This PR temporarily removes `mode` parameter to restore functionality. A backwards-compatible TON Connect update with proper parameter ordering will be implemented in the future.