### PR TITLE
Switch TON Space to alternative bridge url temporarily

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -8,7 +8,7 @@
     "bridge": [
       {
         "type": "sse",
-        "url": "https://bridge.ton.space/bridge"
+        "url": "https://walletbot.me/tonconnect-bridge/bridge"
       }
     ],
     "platforms": ["ios", "android", "macos", "windows", "linux"]


### PR DESCRIPTION
MetaMask is currently flagging TON Space's bridge domain as suspicious, affecting all desktop TON dApps users who have the MetaMask extension installed. 

This PR temporarily changes the bridge url to an alternative domain while we work with MetaMask team to whitelist the original domain. This change ensures uninterrupted functionality for desktop users.