### PR TITLE
feat: reorganize wallets list for 09-12-2024

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -60,6 +60,24 @@
     ]
   },
   {
+    "app_name": "tonhub",
+    "name": "Tonhub",
+    "image": "https://tonhub.com/tonconnect_logo.png",
+    "about_url": "https://tonhub.com",
+    "universal_url": "https://tonhub.com/ton-connect",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "tonhub"
+      },
+      {
+        "type": "sse",
+        "url": "https://connect.tonhubapi.com/tonconnect"
+      }
+    ],
+    "platforms": ["ios", "android"]
+  },
+  {
     "app_name": "bitgetTonWallet",
     "name": "Bitget Wallet",
     "image": "https://raw.githubusercontent.com/bitgetwallet/download/refs/heads/main/logo/png/bitget_wallet_logo_288_mini.png",
@@ -77,6 +95,20 @@
     ],
     "platforms": ["ios", "android", "chrome"],
     "universal_url": "https://bkcode.vip/ton-connect"
+  },
+  {
+    "app_name": "okxMiniWallet",
+    "name": "OKX Mini Wallet",
+    "image": "https://static.okx.com/cdn/assets/imgs/2411/8BE1A4A434D8F58A.png",
+    "about_url": "https://www.okx.com/web3",
+    "universal_url": "https://t.me/OKX_WALLET_BOT?attach=wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://www.okx.com/tonbridge/discover/rpc/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "macos", "windows", "linux"]
   },
   {
     "app_name": "binanceWeb3TonWallet",
@@ -112,84 +144,6 @@
     "platforms": ["ios", "android", "macos", "windows", "linux"]
   },
   {
-    "app_name": "dewallet",
-    "name": "DeWallet",
-    "image": "https://raw.githubusercontent.com/delab-team/manifests-images/main/WalletAvatar.png",
-    "about_url": "https://delabwallet.com",
-    "universal_url": "https://t.me/dewallet?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://bridge.dewallet.pro/bridge"
-      }
-    ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
-  },
-  {
-    "app_name": "safepalwallet",
-    "name": "SafePal",
-    "image": "https://s.pvcliping.com/web/public_image/SafePal_x288.png",
-    "tondns":  "",
-    "about_url": "https://www.safepal.com",
-    "universal_url": "https://link.safepal.io/ton-connect",
-    "deepLink": "safepal-tc://",
-    "bridge": [
-      {
-          "type": "sse",
-          "url": "https://ton-bridge.safepal.com/tonbridge/v1/bridge"
-      },
-      {
-          "type": "js",
-          "key": "safepalwallet"
-      }
-    ],
-    "platforms": ["ios", "android", "chrome", "firefox"]
-  },
-  {
-    "app_name": "openmask",
-    "name": "OpenMask",
-    "image": "https://raw.githubusercontent.com/OpenProduct/openmask-extension/main/public/openmask-logo-288.png",
-    "about_url": "https://www.openmask.app/",
-    "bridge": [
-      {
-        "type": "js",
-        "key": "openmask"
-      }
-    ],
-    "platforms": ["chrome"]
-  },
-  {
-    "app_name": "tonhub",
-    "name": "Tonhub",
-    "image": "https://tonhub.com/tonconnect_logo.png",
-    "about_url": "https://tonhub.com",
-    "universal_url": "https://tonhub.com/ton-connect",
-    "bridge": [
-      {
-        "type": "js",
-        "key": "tonhub"
-      },
-      {
-        "type": "sse",
-        "url": "https://connect.tonhubapi.com/tonconnect"
-      }
-    ],
-    "platforms": ["ios", "android"]
-  },
-  {
-    "app_name": "xtonwallet",
-    "name": "XTONWallet",
-    "image": "https://xtonwallet.com/assets/img/icon-256-back.png",
-    "about_url": "https://xtonwallet.com",
-    "bridge": [
-      {
-        "type": "js",
-        "key": "xtonwallet"
-      }
-    ],
-    "platforms": ["chrome", "firefox"]
-  },
-  {
     "app_name": "okxTonWallet",
     "name": "OKX Wallet",
     "image": "https://static.okx.com/cdn/assets/imgs/247/58E63FEA47A2B7D7.png",
@@ -206,20 +160,6 @@
       }
     ],
     "platforms": ["chrome", "safari", "firefox", "ios", "android"]
-  },
-  {
-    "app_name": "okxMiniWallet",
-    "name": "OKX Mini Wallet",
-    "image": "https://static.okx.com/cdn/assets/imgs/2411/8BE1A4A434D8F58A.png",
-    "about_url": "https://www.okx.com/web3",
-    "universal_url": "https://t.me/OKX_WALLET_BOT?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://www.okx.com/tonbridge/discover/rpc/bridge"
-      }
-    ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
   },
   {
     "app_name": "hot",
@@ -259,6 +199,40 @@
     "platforms": ["ios", "android", "chrome"]
   },
   {
+    "app_name": "dewallet",
+    "name": "DeWallet",
+    "image": "https://raw.githubusercontent.com/delab-team/manifests-images/main/WalletAvatar.png",
+    "about_url": "https://delabwallet.com",
+    "universal_url": "https://t.me/dewallet?attach=wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.dewallet.pro/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "macos", "windows", "linux"]
+  },
+  {
+    "app_name": "safepalwallet",
+    "name": "SafePal",
+    "image": "https://s.pvcliping.com/web/public_image/SafePal_x288.png",
+    "tondns":  "",
+    "about_url": "https://www.safepal.com",
+    "universal_url": "https://link.safepal.io/ton-connect",
+    "deepLink": "safepal-tc://",
+    "bridge": [
+      {
+          "type": "sse",
+          "url": "https://ton-bridge.safepal.com/tonbridge/v1/bridge"
+      },
+      {
+          "type": "js",
+          "key": "safepalwallet"
+      }
+    ],
+    "platforms": ["ios", "android", "chrome", "firefox"]
+  },
+  {
     "app_name": "GateWallet",
     "name": "GateWallet",
     "image": "https://img.gatedataimg.com/prd-ordinal-imgs/036f07bb8730716e/gateio-0925.png",
@@ -277,31 +251,17 @@
     "universal_url": "https://gateio.go.link/gateio/web3?adj_t=1ff8khdw_1fu4ccc7"
   },
   {
-    "app_name": "tonwallet",
-    "name": "TON Wallet",
-    "image": "https://wallet.ton.org/assets/ui/qr-logo.png",
-    "about_url": "https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd",
+    "app_name": "openmask",
+    "name": "OpenMask",
+    "image": "https://raw.githubusercontent.com/OpenProduct/openmask-extension/main/public/openmask-logo-288.png",
+    "about_url": "https://www.openmask.app/",
     "bridge": [
       {
         "type": "js",
-        "key": "tonwallet"
+        "key": "openmask"
       }
     ],
     "platforms": ["chrome"]
-  },
-  {
-    "app_name": "BitgetWeb3",
-    "name": "BitgetWeb3",
-    "image": "https://img.bitgetimg.com/image/third/1731638059795.png",
-    "about_url": "​https://www.bitget.com",
-    "universal_url": "https://t.me/BitgetOfficialBot?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
-      }
-    ],
-    "platforms": ["ios", "android", "windows", "macos", "linux"]
   },
   {
     "app_name": "tobi",
@@ -322,5 +282,45 @@
       "windows",
       "linux"
     ]
+  },
+  {
+    "app_name": "BitgetWeb3",
+    "name": "BitgetWeb3",
+    "image": "https://img.bitgetimg.com/image/third/1731638059795.png",
+    "about_url": "​https://www.bitget.com",
+    "universal_url": "https://t.me/BitgetOfficialBot?attach=wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "windows", "macos", "linux"]
+  },
+  {
+    "app_name": "xtonwallet",
+    "name": "XTONWallet",
+    "image": "https://xtonwallet.com/assets/img/icon-256-back.png",
+    "about_url": "https://xtonwallet.com",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "xtonwallet"
+      }
+    ],
+    "platforms": ["chrome", "firefox"]
+  },
+  {
+    "app_name": "tonwallet",
+    "name": "TON Wallet",
+    "image": "https://wallet.ton.org/assets/ui/qr-logo.png",
+    "about_url": "https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "tonwallet"
+      }
+    ],
+    "platforms": ["chrome"]
   }
 ]

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -264,6 +264,20 @@
     "platforms": ["chrome"]
   },
   {
+    "app_name": "BitgetWeb3",
+    "name": "BitgetWeb3",
+    "image": "https://img.bitgetimg.com/image/third/1731638059795.png",
+    "about_url": "​https://www.bitget.com",
+    "universal_url": "https://t.me/BitgetOfficialBot?attach=wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "windows", "macos", "linux"]
+  },
+  {
     "app_name": "tobi",
     "name": "Tobi",
     "image": "https://app.tobiwallet.app/icons/logo-288.png",
@@ -282,20 +296,6 @@
       "windows",
       "linux"
     ]
-  },
-  {
-    "app_name": "BitgetWeb3",
-    "name": "BitgetWeb3",
-    "image": "https://img.bitgetimg.com/image/third/1731638059795.png",
-    "about_url": "​https://www.bitget.com",
-    "universal_url": "https://t.me/BitgetOfficialBot?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://ton-connect-bridge.bgwapi.io/bridge"
-      }
-    ],
-    "platforms": ["ios", "android", "windows", "macos", "linux"]
   },
   {
     "app_name": "xtonwallet",


### PR DESCRIPTION
This PR updates the order of wallets in the `wallets-list.json` based on the latest analytics data from December 9, 2024 of wallet usage and adoption rates. The new order reflects actual market penetration and user preferences, which should provide a better user experience by presenting the most commonly used wallets first.

The updated order prioritizes wallets with higher user engagement while maintaining support for all existing integrations. This change is purely presentational and does not affect any functional aspects of TON Connect.