### PR TITLE
Update Add Gate.io mini_wallet to wallets-v2.json

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -336,5 +336,19 @@
       }
     ],
     "platforms": ["ios", "android", "macos", "windows", "linux"]
-  }
+  },
+  {
+    "app_name": "Gate.io wallet",
+    "name": "Gate.io wallet",
+    "image": "https://gimg2.gateimg.com/tgwallet/1730688473495507406-Gatewallet.png",
+    "about_url": "https://www.gate.io",
+    "universal_url": "https://t.me/gateio_wallet_bot?attach=wallet", 
+    "bridge": [ 
+       {
+          "type": "sse",
+          "url": "https://dapp.gateio.services/tonbridge_api/bridge/v1"
+       }
+    ],
+    "platforms": ["ios", "android", "chrome", "windows", "macos"]
+    }
 ]


### PR DESCRIPTION
update wallet json

# Add <Gate.io_mini_wallet> wallet

## Supports
- [ ] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [x] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](https://ton-connect.github.io/demo-dapp-with-react-ui/)

## Integrator contacts
* telegram
* email
* discord
* ...
