### PR TITLE
Add Architec.ton wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -350,5 +350,19 @@
       }
     ],
     "platforms": ["ios", "android", "macos", "windows", "linux"]
-  }
+  },
+  {
+    "app_name": "Architec.ton",
+    "name": "Architec.ton",
+    "image": "https://raw.githubusercontent.com/Architec-Ton/wallet-tma/refs/heads/dev/public/images/arcwallet_logo.png",
+    "about_url": "https://architecton.tech",
+    "universal_url": "https://t.me/architec_ton_bot?attach=wallet",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://tc.architecton.su/bridge"
+      }
+    ],
+    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    }
 ]


### PR DESCRIPTION
# Add Architec.ton wallet

## Supports
- [x]  HTTP bridge as a wallet app for TG

## Supported features
- [x]  ton_proof
- [x]  SendTransaction

## Test
https://demo-dapp-with-wallet-ten.vercel.app/

## Integrator contacts
telegram: @stanta 
telegram: @egorkqq 
email: st@architecton.tech
email: egor@architecton.tech
