### PR TITLE
Added defiway ton wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -350,5 +350,21 @@
       }
     ],
     "platforms": ["ios", "android", "macos", "windows", "linux"]
+  },
+  {
+    "app_name": "defiway_tonwallet",
+    "name": "Defiway TON Wallet",
+    "image": "https://fs.defiway.com/icons/defiway.png",
+    "about_url": "https://wallet.defiway.com",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
+      },{
+        "type": "js",
+        "key": "defiway_tonwallet"
+      }
+    ],
+    "platforms": ["ios", "android", "chrome", "firefox", "safari"]
   }
 ]

--- a/wallets.json
+++ b/wallets.json
@@ -118,5 +118,21 @@
       }
     ],
     "platforms": ["chrome"]
+  },
+  {
+    "app_name": "defiway_tonwallet",
+    "name": "Defiway TON Wallet",
+    "image": "https://fs.defiway.com/icons/defiway.png",
+    "about_url": "https://wallet.defiway.com",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
+      },{
+        "type": "js",
+        "key": "defiway_tonwallet"
+      }
+    ],
+    "platforms": ["ios", "android", "chrome", "firefox", "safari"]
   }
 ]


### PR DESCRIPTION
# Add Defiway wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](https://wallet.defiway.com), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [ ] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)