### PR TITLE
Add defiway wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -351,5 +351,24 @@
       }
     ],
     "platforms": ["ios", "android", "macos", "windows", "linux"]
+  },
+  {
+    "app_name": "defiway",
+    "name": "Defiway",
+    "image": "https://fs.defiway.com/icons/tonconnect-icon.png",
+    "about_url": "https://wallet.defiway.com",
+    "universal_url": "https://wallet.defiway.com/ton-connect",
+    "deepLink": "defiway-tc://",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://api.defiway.com/ton-connect"
+      },
+      {
+        "type": "js",
+        "key": "defiway"
+      }
+    ],
+    "platforms": ["ios", "android", "chrome", "safari"]
   }
 ]


### PR DESCRIPTION
# Add Defiway wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](https://chromewebstore.google.com/detail/defiway-extension/fpcbdmghkplbhioajildoodhfgnokiek) browser.
- [x] JS bridge for the in-wallet browser for [iOS](https://apps.apple.com/app/defiway-crypto-wallet/id6468950298) and [Android](https://fs.defiway.com/wallet/defiway-latest-release.apk).
- [x] HTTP bridge as a mobile wallet app for [iOS](https://apps.apple.com/app/defiway-crypto-wallet/id6468950298) and [Android](https://fs.defiway.com/wallet/defiway-latest-release.apk).

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)

## Integrator contacts
* [telegram](https://t.me/defiway_support)
* dev@defiway.com