### PR TITLE
feat: add supported features to wallet manifests

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -11,7 +11,14 @@
         "url": "https://walletbot.me/tonconnect-bridge/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "tonkeeper",
@@ -31,7 +38,14 @@
         "key": "tonkeeper"
       }
     ],
-    "platforms": ["ios", "android", "chrome", "firefox", "macos"]
+    "platforms": ["ios", "android", "chrome", "firefox", "macos"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 255,
+        "extraCurrencySupported": true
+      }
+    ]
   },
   {
     "app_name": "mytonwallet",
@@ -58,6 +72,13 @@
       "ios",
       "android",
       "firefox"
+    ],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
     ]
   },
   {
@@ -76,7 +97,14 @@
         "url": "https://connect.tonhubapi.com/tonconnect"
       }
     ],
-    "platforms": ["ios", "android"]
+    "platforms": ["ios", "android"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "bitgetTonWallet",
@@ -95,7 +123,14 @@
       }
     ],
     "platforms": ["ios", "android", "chrome"],
-    "universal_url": "https://bkcode.vip/ton-connect"
+    "universal_url": "https://bkcode.vip/ton-connect",
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "okxMiniWallet",
@@ -109,7 +144,14 @@
         "url": "https://www.okx.com/tonbridge/discover/rpc/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "binanceWeb3TonWallet",
@@ -128,7 +170,14 @@
       }
     ],
     "platforms":  ["ios", "android", "macos", "windows", "linux"],
-    "universal_url": "https://app.binance.com/cedefi/ton-connect"
+    "universal_url": "https://app.binance.com/cedefi/ton-connect",
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "fintopio-tg",
@@ -142,7 +191,14 @@
         "url": "https://wallet-bridge.fintopio.com/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "okxTonWallet",
@@ -160,7 +216,14 @@
         "url": "https://www.okx.com/tonbridge/discover/rpc/bridge"
       }
     ],
-    "platforms": ["chrome", "safari", "firefox", "ios", "android"]
+    "platforms": ["chrome", "safari", "firefox", "ios", "android"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "hot",
@@ -178,7 +241,14 @@
         "key": "hotWallet"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "bybitTonWallet",
@@ -197,7 +267,14 @@
         "url": "https://api-node.bybit.com/spot/api/web3/bridge/ton/bridge"
       }
     ],
-    "platforms": ["ios", "android", "chrome"]
+    "platforms": ["ios", "android", "chrome"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "dewallet",
@@ -211,27 +288,41 @@
         "url": "https://bridge.dewallet.pro/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "safepalwallet",
     "name": "SafePal",
     "image": "https://s.pvcliping.com/web/public_image/SafePal_x288.png",
-    "tondns":  "",
+    "tondns": "",
     "about_url": "https://www.safepal.com",
     "universal_url": "https://link.safepal.io/ton-connect",
     "deepLink": "safepal-tc://",
     "bridge": [
       {
-          "type": "sse",
-          "url": "https://ton-bridge.safepal.com/tonbridge/v1/bridge"
+        "type": "sse",
+        "url": "https://ton-bridge.safepal.com/tonbridge/v1/bridge"
       },
       {
-          "type": "js",
-          "key": "safepalwallet"
+        "type": "js",
+        "key": "safepalwallet"
       }
     ],
-    "platforms": ["ios", "android", "chrome", "firefox"]
+    "platforms": ["ios", "android", "chrome", "firefox"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 1,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "GateWallet",
@@ -249,7 +340,14 @@
       }
     ],
     "platforms": ["ios", "android"],
-    "universal_url": "https://gateio.go.link/gateio/web3?adj_t=1ff8khdw_1fu4ccc7"
+    "universal_url": "https://gateio.go.link/gateio/web3?adj_t=1ff8khdw_1fu4ccc7",
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "openmask",
@@ -262,7 +360,14 @@
         "key": "openmask"
       }
     ],
-    "platforms": ["chrome"]
+    "platforms": ["chrome"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "BitgetWeb3",
@@ -276,7 +381,14 @@
         "url": "https://ton-connect-bridge.bgwapi.io/bridge"
       }
     ],
-    "platforms": ["ios", "android", "windows", "macos", "linux"]
+    "platforms": ["ios", "android", "windows", "macos", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "tobi",
@@ -296,6 +408,13 @@
       "macos",
       "windows",
       "linux"
+    ],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
     ]
   },
   {
@@ -309,7 +428,14 @@
         "key": "xtonwallet"
       }
     ],
-    "platforms": ["chrome", "firefox"]
+    "platforms": ["chrome", "firefox"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 1,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "tonwallet",
@@ -322,7 +448,14 @@
         "key": "tonwallet"
       }
     ],
-    "platforms": ["chrome"]
+    "platforms": ["chrome"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "bitgetWalletLite",
@@ -336,7 +469,14 @@
         "url": "https://ton-connect-bridge.bgwapi.io/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "tomoWallet",
@@ -350,7 +490,14 @@
         "url": "https://go-bridge.tomo.inc/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "miraiapp-tg",
@@ -362,9 +509,16 @@
       {
         "type": "sse",
         "url": "https://bridge.mirai.app"
-     }
+      }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   },
   {
     "app_name": "Architec.ton",
@@ -378,6 +532,13 @@
         "url": "https://tc.architecton.su/bridge"
       }
     ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"]
+    "platforms": ["ios", "android", "macos", "windows", "linux"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 255,
+        "extraCurrencySupported": false
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds supported features information to the wallets-list manifests.

Previously, wallets only reported their supported features during connection. Now this information is included directly in the wallets-list, allowing dApps to filter compatible wallets before connection based on required features.