### PR TITLE
feat: add extra currency support for telegram wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -16,7 +16,7 @@
       {
         "name": "SendTransaction",
         "maxMessages": 4,
-        "extraCurrencySupported": false
+        "extraCurrencySupported": true
       }
     ]
   },


### PR DESCRIPTION
@wallet team has informed that they've added support for extra currency. This pr updates their manifest to reflect this new capability, allowing dApps to utilize this feature.