### PR TITLE
Add TonGate wallet to registry

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -575,5 +575,26 @@
      }
     ],
     "platforms": ["ios", "android", "macos", "windows", "linux"]
+  },
+  {
+    "app_name": "tongate",
+    "name": "TonGate",
+    "image": "https://tongate.app/assets/images/tongate_icon.png",
+    "about_url": "https://tongate.app",
+    "universal_url": "https://tongate.app/connect",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
+      }
+    ],
+    "platforms": ["ios", "android"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 4,
+        "extraCurrencySupported": false
+      }
+    ]
   }
 ]

--- a/wallets.json
+++ b/wallets.json
@@ -118,5 +118,19 @@
       }
     ],
     "platforms": ["chrome"]
+  },
+  {
+    "app_name": "tongate",
+    "name": "TonGate",
+    "image": "https://tongate.app/assets/images/tongate_icon.png",
+    "about_url": "https://tongate.app",
+    "universal_url": "https://tongate.app/connect",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
+      }
+    ],
+    "platforms": ["ios", "android"]
   }
 ]


### PR DESCRIPTION
# Add Tongate wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [x] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests


## Integrator contacts

