### PR TITLE
feat: update wallet features for Wallet in Telegram, MyTonWallet and Tonhub

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -15,7 +15,7 @@
     "features": [
       {
         "name": "SendTransaction",
-        "maxMessages": 4,
+        "maxMessages": 255,
         "extraCurrencySupported": true
       }
     ]
@@ -76,7 +76,7 @@
     "features": [
       {
         "name": "SendTransaction",
-        "maxMessages": 4,
+        "maxMessages": 255,
         "extraCurrencySupported": false
       }
     ]
@@ -101,8 +101,8 @@
     "features": [
       {
         "name": "SendTransaction",
-        "maxMessages": 4,
-        "extraCurrencySupported": false
+        "maxMessages": 255,
+        "extraCurrencySupported": true
       }
     ]
   },


### PR DESCRIPTION
This PR updates the feature specifications for ecosystem wallets:
- Wallet in Telegram: Increased max messages limit from 4 to 255
- MyTonWallet: Increased max messages limit from 4 to 255  
- Tonhub: Increased max messages limit from 4 to 255 and enabled extra currency supported
