### PR TITLE
Add Fearless Wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -598,5 +598,23 @@
         "extraCurrencySupported": true
       }
     ]
+  },
+  {
+    "app_name": "Fearless",
+    "name": "Fearless",
+    "image": "https://raw.githubusercontent.com/soramitsu/shared-features-utils/master/icons/FW_icon_288.png",
+    "about_url": "https://fearlesswallet.io",
+    "universal_url": "https://fearlesswallet.io/ton-connect",
+    "bridge": [
+       {
+          "type": "sse",
+          "url": "https://fearless-ton-bridge.odachi.soramitsu.co.jp/bridge"
+       },
+       {
+          "type": "js",
+          "key": "Fearless"
+       }
+    ],
+    "platforms": ["ios", "android"]
   }
 ]


### PR DESCRIPTION
# Add Fearless wallet

## Supports
- [x] JS bridge for the in-wallet browser for [iOS](https://apps.apple.com/us/app/fearless-wallet-defi-wallet/id1537251089) 
- [x] HTTP bridge as a mobile wallet app for [iOS](https://apps.apple.com/us/app/fearless-wallet-defi-wallet/id1537251089)

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[Fearless Wallet DEMO App](https://ton-connect.example.fearless.soramitsu.co.jp)

## Integrator contacts
* telegram: @catswithouthats
* telegram: @alexg6r
* email: fearless@soramitsu.co.jp
* email: richter@soramitsu.co.jp