### PR TITLE
Update universal URL for GateWallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -340,7 +340,7 @@
       }
     ],
     "platforms": ["ios", "android"],
-    "universal_url": "https://gateio.go.link/gateio/web3?adj_t=1ff8khdw_1fu4ccc7",
+    "universal_url": "https://gate.onelink.me/Hls0/web3?gate_web3_wallet_universal_type=ton_connect",
     "features": [
       {
         "name": "SendTransaction",


### PR DESCRIPTION
This PR updates the universal URL for **GateWallet** in the Ton Connect registry.  

### Changes:  
- Updated universal link from `https://gateio.go.link/gateio/web3?adj_t=1ff8khdw_1fu4ccc7` to `https://gate.onelink.me/Hls0/web3?gate_web3_wallet_universal_type=ton_connect`  

### Verification:  
- Tested deep linking functionality with https://ton-connect.github.io/demo-dapp-with-react-ui/
- Confirmed successful transaction signing via the new URL  

**Reason for update:**  
Improved universal link reliability

## Tests
iOS
https://apps.apple.com/us/app/gate-trade-btc-eth/id1294998195
Android
https://play.google.com/store/apps/details?id=com.gateio.gateio
