### PR TITLE
add Cactus Link wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -647,5 +647,31 @@
       }
     ],
     "platforms": ["ios", "android"]
+  },
+  {
+    "app_name": "cactuslink",
+    "name": "Cactus Link",
+    "image": "https://downloads.mycactus.com/288_cactus_link.png",
+    "about_url": "https://www.mycactus.com/defi-connector",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "cactuslink_ton"
+      }
+    ],
+    "platforms": ["chrome"],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 255,
+        "extraCurrencySupported": false
+      },
+      {
+          "name": "SignData",
+          "types": [
+            "text", "binary"
+          ]
+        }
+    ]
   }
 ]

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -748,7 +748,7 @@
     "features": [
       {
         "name": "SendTransaction",
-        "maxMessages": 255,
+        "maxMessages": 4,
         "extraCurrencySupported": false
       },
       {


### PR DESCRIPTION
# Add Cactus Link wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [ ] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](link)

## Integrator contacts
* telegram
* email
* discord
* ...
