### PR TITLE
feat: remove Tobi wallet temporarily due to bridge issues

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -407,33 +407,6 @@
     ]
   },
   {
-    "app_name": "tobi",
-    "name": "Tobi",
-    "image": "https://app.tobiwallet.app/icons/logo-288.png",
-    "about_url": "https://tobi.fun",
-    "universal_url": "https://t.me/TobiCopilotBot?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://ton-bridge.tobiwallet.app/bridge"
-      }
-    ],
-    "platforms": [
-      "ios",
-      "android",
-      "macos",
-      "windows",
-      "linux"
-    ],
-    "features": [
-      {
-        "name": "SendTransaction",
-        "maxMessages": 4,
-        "extraCurrencySupported": false
-      }
-    ]
-  },
-  {
     "app_name": "xtonwallet",
     "name": "XTONWallet",
     "image": "https://xtonwallet.com/assets/img/icon-256-back.png",


### PR DESCRIPTION
Temporarily removing Tobi wallet from the supported wallets list due to non-functional bridge and lack of response from the team. The wallet will be re-added once the technical issues are resolved and communication is restored.