### PR TITLE
Added `windows` and `linux` in platform list of wallets-v2 for tonkeeper

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -42,7 +42,7 @@
         "key": "tonkeeper"
       }
     ],
-    "platforms": ["ios", "android", "chrome", "firefox", "macos"],
+    "platforms": ["ios", "android", "chrome", "firefox", "macos", "windows", "linux"],
     "features": [
       {
         "name": "SendTransaction",


### PR DESCRIPTION
Added `windows` and `linux` in platform list for tonkeeper
