### PR TITLE
feat: remove blitzwallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -648,27 +648,6 @@
     ]
   },
   {
-    "app_name": "blitzwallet",
-    "name": "BLITZ wallet",
-    "image": "https://blitzwallet.cfd/wallet/public/logo.png",
-    "about_url": "https://blitzwallet.cfd",
-    "universal_url": "https://t.me/blitz_wallet_bot?attach=wallet",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://blitzwallet.cfd/bridge/"
-      }
-    ],
-    "platforms": ["ios", "android", "macos", "windows", "linux"],
-    "features": [
-      {
-        "name": "SendTransaction",
-        "maxMessages": 4,
-        "extraCurrencySupported": false
-      }
-    ]
-  },
-  {
     "app_name": "koloWeb3Wallet",
     "name": "Kolo",
     "image": "https://raw.githubusercontent.com/onidev1/tc-assets/refs/heads/main/kolo_logo_288.png",


### PR DESCRIPTION
Removing this wallet as it currently appears non-functional.

If you maintain this wallet and would like to restore the wallet in TON Connect, please reach out via Telegram to https://t.me/kawaiinya and we'll be happy to review.