### PR TITLE
Added Bron wallet to wallet-list

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -850,7 +850,7 @@
  {
   "app_name": "bron",
   "name": "Bron",
-  "image": "https://cdn.nobr.io/static/ton-connect/bron-logo-288.png",
+  "image": "https://cdn.bron.org/static/ton-connect/bron-logo-288.png",
   "about_url": "https://bron.org",
   "universal_url": "https://app.bron.org/ton-connect",
   "deepLink": "bron://ton-connect",
@@ -860,7 +860,7 @@
       "url": "https://ton-connect.bron.org/bridge"
     }
   ],
-  "platforms": ["windows", "macos", "linux", "ios", "android"],
+  "platforms": ["windows", "macos", "ios", "android"],
   "features": [
     {
       "name": "SendTransaction",

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -846,5 +846,31 @@
     }
   ],
   "platforms": ["ios", "android"]
+ },
+ {
+  "app_name": "bron",
+  "name": "Bron",
+  "image": "https://cdn.nobr.io/static/ton-connect/bron-logo-288.png",
+  "about_url": "https://bron.org",
+  "universal_url": "https://app.bron.org/ton-connect",
+  "deepLink": "bron://ton-connect",
+  "bridge": [
+    {
+      "type": "sse",
+      "url": "https://ton-connect.bron.org/bridge"
+    }
+  ],
+  "platforms": ["windows", "macos", "linux", "ios", "android"],
+  "features": [
+    {
+      "name": "SendTransaction",
+      "maxMessages": 255,
+      "extraCurrencySupported": false
+    },
+    {
+      "name": "SignData",
+      "types": ["text", "binary", "cell"]
+    }
+  ]
  }
 ]


### PR DESCRIPTION
# Add Bron wallet

## Supports
- [ ] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<link>) and [Android](<link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](soon) and [Android](https://play.google.com/store/apps/details?id=org.bron.mobile).
- [x] HTTP bridge as a desctop wallet app for [Windows](https://app.bron.org/), [macOS](https://app.bron.org/), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)
- [x] SignData (`text`, `binary`, `cell`)


## Tests
* tested swaps on ston.fi
* tested nft actions on getgems.io

## Integrator contacts
* telegram [@horus20](https://t.me/horus20)

Desktop builds (win/macOS) are available from the web app at `app.bron.org` — links rotate per release.
iOS application on review, will be available soon.