### PR TITLE
nginx: add CORS, server_tokens off

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -12,6 +12,9 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Hide the nginx version (and the exact patch version) from the Server header.
+    server_tokens off;
+
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent"';
@@ -24,14 +27,40 @@ http {
 
         root /usr/share/nginx/html;
 
+        # CORS headers — dApps fetch wallets-v2.json cross-origin, so these must stay
+        # on the response. add_header in a location resets inherited ones, so the CORS
+        # set is repeated in each location alongside its Cache-Control.
         location /assets/ {
+            # CORS preflight: answer OPTIONS with 204 (bare nginx returns 405).
+            # add_header inside an `if` does NOT inherit the location-level set, so the
+            # CORS headers are repeated inside the block.
+            if ($request_method = 'OPTIONS') {
+                add_header Access-Control-Allow-Origin "*" always;
+                add_header Access-Control-Allow-Methods "PUT, GET, POST, OPTIONS, DELETE" always;
+                add_header Access-Control-Allow-Headers "Content-Type,Cache-Control" always;
+                add_header Access-Control-Allow-Credentials "true" always;
+                add_header Access-Control-Max-Age "1728000" always;
+                add_header Content-Type "text/plain; charset=utf-8" always;
+                add_header Content-Length 0 always;
+                return 204;
+            }
             try_files $uri =404;
-            add_header Cache-Control "public, max-age=21600"; # 6 hours
+            add_header Cache-Control "public, max-age=21600" always; # 6 hours
+            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Methods "PUT, GET, POST, OPTIONS, DELETE" always;
+            add_header Access-Control-Allow-Headers "Content-Type,Cache-Control" always;
+            add_header Access-Control-Allow-Credentials "true" always;
+            add_header Access-Control-Max-Age "1728000" always;
         }
 
         location / {
             try_files $uri $uri/ =404;
-            add_header Cache-Control "public, max-age=180"; # 3 minutes
+            add_header Cache-Control "public, max-age=180" always; # 3 minutes
+            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Methods "PUT, GET, POST, OPTIONS, DELETE" always;
+            add_header Access-Control-Allow-Headers "Content-Type,Cache-Control" always;
+            add_header Access-Control-Allow-Credentials "true" always;
+            add_header Access-Control-Max-Age "1728000" always;
         }
 
         location = / {


### PR DESCRIPTION
Adds standard response headers to the static nginx server:

- `server_tokens off` — don't expose the nginx version.
- CORS headers on the asset and JSON locations, plus an `OPTIONS` preflight returning 204 — `wallets-v2.json` is fetched cross-origin by dApps, so the headers must be present on the response.

Headers only — no content change.