### PR TITLE
chore: add version.yaml release pointer

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -1,0 +1,4 @@
+# Release pointer: the published deployment tracks exactly this commit.
+# Changes to this file intentionally do not trigger image builds.
+branch: main
+sha: 847cdce


### PR DESCRIPTION
Adds a `version.yaml` at the repo root that records which commit the published deployment currently tracks.

The build workflow ignores this path, so edits to the pointer intentionally do not trigger image builds. It is updated independently of source changes when a release is promoted.