### PR TITLE
chore: correct release pointer and nest fields under release

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -1,4 +1,5 @@
 # Release pointer: the published deployment tracks exactly this commit.
 # Changes to this file intentionally do not trigger image builds.
-branch: main
-sha: 847cdce
+release:
+  branch: main
+  sha: 9adfc57


### PR DESCRIPTION
Update the release pointer so it tracks the build that is actually published, rather than a stale sha that has no matching commit or image tag.

Also group the pointer fields under a top-level `release` key for a clearer, namespaced structure.

This file is intentionally excluded from the image build triggers, so the change does not produce a new image.