### PR TITLE
chore: drop pinned image tag from service.yaml

### DIFF
--- a/service.yaml
+++ b/service.yaml
@@ -3,8 +3,6 @@ apiVersion: idp.mw.me/v1
 # `name` pins the flat service name; the default would be the org-qualified {org}-{repo}.
 name: wallets-list
 container-name: nginx
-image:
-  tag: e6c692c
 replicas: 2
 arch: arm64
 route:


### PR DESCRIPTION
The deployment version is tracked by `version.yaml`'s release pointer, which the platform injects into the Helm render as `image.tag`. The static `tag` carried in this descriptor is no longer read at deploy time, so it is redundant and risks misleading readers about which image is live.

Removing it is a no-op for the running deployment and only clarifies the descriptor's contract.