### PR TITLE
test: probe release-pointer check (do not merge)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 9adfc57
+  sha: deadbee


### PR DESCRIPTION
Throwaway draft to exercise the new `Verify release pointer` check against an unpublished sha. Will be closed without merging.