### PR TITLE
chore: update release pointer to 9f0a45e

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 9adfc57
+  sha: 9f0a45e


### PR DESCRIPTION
Advance the published release pointer to the latest built commit.

Pointer-only change; no image rebuild.