### PR TITLE
chore: roll release pointer back to 9adfc57

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 9f0a45e
+  sha: 9adfc57


### PR DESCRIPTION
Restore the previous published build.

Pointer-only change; no image rebuild.