### PR TITLE
Restore Gram Wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -56,6 +56,44 @@
     ]
   },
   {
+    "app_name": "gramwallet",
+    "name": "Gram Wallet",
+    "image": "https://static.gramwallet.io/gramwallet/icon-288.png",
+    "about_url": "https://gramwallet.io",
+    "universal_url": "https://connect.gramwallet.io",
+    "deepLink": "gramwallet-tc://",
+    "bridge": [
+      {
+        "type": "js",
+        "key": "gramwallet"
+      },
+      {
+        "type": "sse",
+        "url": "https://tonconnectbridge.mytonwallet.org/bridge/"
+      }
+    ],
+    "platforms": [
+      "chrome",
+      "windows",
+      "macos",
+      "linux",
+      "ios",
+      "android",
+      "firefox"
+    ],
+    "features": [
+      {
+        "name": "SendTransaction",
+        "maxMessages": 255,
+        "extraCurrencySupported": false
+      },
+      {
+        "name": "SignData",
+        "types": ["text", "binary", "cell"]
+      }
+    ]
+  },
+  {
     "app_name": "mytonwallet",
     "name": "MyTonWallet",
     "image": "https://static.mytonwallet.io/icon-256.png",


### PR DESCRIPTION
Re-apply the Gram Wallet listing added in #253 (`db0dab4`), which was removed temporarily in #254 (`6eafec8`).

This is a revert of the revert: it restores only the 38-line `wallets-v2.json` entry. The `assets/gramwallet.png` asset was never removed by #254, so no asset change is needed.

Validations (tests.yml) pass locally: wallet validation, JSON-schema, assets — all green.