### PR TITLE
chore: roll release pointer to dc7917a (Gram Wallet)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 9adfc57
+  sha: dc7917a


### PR DESCRIPTION
Advance the release pointer to `dc7917a` (#272, Restore Gram Wallet), now built and published to ECR.

This is the deploy step: merging it makes ArgoCD roll the published image carrying the restored Gram Wallet entry onto prod (config.ton.org).

- release.branch: main
- release.sha: 9adfc57 → dc7917a

`verify-release-pointer` gates this: schema, provenance (sha reachable from main), and ECR image existence.