### PR TITLE
chore: raise wallets-v2.json cache TTL to 3h (stale-while-revalidate)

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -68,7 +68,7 @@ http {
                 return 204;
             }
             try_files $uri $uri/ =404;
-            add_header Cache-Control "public, max-age=180" always; # 3 minutes
+            add_header Cache-Control "public, max-age=10800, stale-while-revalidate=86400" always; # 3h fresh, serve-stale up to 24h while revalidating
             add_header Access-Control-Allow-Origin "*" always;
             add_header Access-Control-Allow-Methods "PUT, GET, POST, OPTIONS, DELETE" always;
             add_header Access-Control-Allow-Headers "Content-Type,Cache-Control" always;


### PR DESCRIPTION
`wallets-v2.json` only changes when a wallet-list PR lands, but the current `max-age=180` makes every client refetch it every 3 minutes.

This raises the TTL to `max-age=10800` (3h) and adds `stale-while-revalidate=86400`, so clients:
- cache the list far longer instead of refetching every 3 min, and
- serve the cached copy instantly while revalidating in the background — a newly added wallet still propagates promptly, without a blocking fetch or a synchronized refetch storm when the TTL expires.

`/assets/` already uses a 6h TTL, so this brings the list closer in line. No content or schema changes.