### PR TITLE
chore: roll release pointer to 69c79b8

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: dc7917a
+  sha: 69c79b8


### PR DESCRIPTION
Rolls the published deployment to `69c79b8`, which carries the `wallets-v2.json` cache-TTL bump (max-age 3h + stale-while-revalidate, #274). Image already built and present in the registry.