### PR TITLE
chore: roll release pointer to 5c84ae2

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 69c79b8
+  sha: 5c84ae2


### PR DESCRIPTION
Roll the published prod deployment pointer to `5c84ae2` ("My Wallet" rebranding, #276).

- Image `wallets-list:5c84ae2` built & published to prod ECR (build run succeeded).
- Staging (HEAD) verified serving `name: "My Wallet"`, `about_url: mywallet.io`.
- Served icon path `/assets/mytonwallet.png` unchanged (app_name unchanged) — no asset breakage.