### PR TITLE
chore: roll release pointer to 529a67a

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 5c84ae2
+  sha: 529a67a


### PR DESCRIPTION
Roll prod deployment pointer `5c84ae2 → 529a67a`.

Includes:
- #282 `529a67a` — My Wallet icon in /assets (assets/mytonwallet.png 4757→24572 bytes)
- #281 `fd2f35f` — Gram Wallet platforms trimmed to ios/android

Both images built & published to prod ECR; staging (HEAD) verified serving new icon (24572 B) + gram platforms ios,android.