### PR TITLE
Add /healthz and /readyz endpoints

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -27,6 +27,23 @@ http {
 
         root /usr/share/nginx/html;
 
+        # Probe endpoints for the liveness and readiness checks. Static 200: nginx serves pre-baked
+        # files, so "process up" is the whole story. A draining instance leaves rotation via the
+        # preStop hook (graceful `nginx -s quit` after a short sleep so the load balancer can
+        # deregister it) plus the pod termination grace period, not by flipping /readyz to 503, which
+        # would need a sidecar and buys nothing for a static file server. access_log off so the
+        # frequent health-check poll does not flood stdout.
+        location = /healthz {
+            access_log off;
+            add_header Content-Type "text/plain; charset=utf-8" always;
+            return 200 "ok\n";
+        }
+        location = /readyz {
+            access_log off;
+            add_header Content-Type "text/plain; charset=utf-8" always;
+            return 200 "ok\n";
+        }
+
         # CORS headers — dApps fetch wallets-v2.json cross-origin, so these must stay
         # on the response. add_header in a location resets inherited ones, so the CORS
         # set is repeated in each location alongside its Cache-Control.


### PR DESCRIPTION
Static 200 endpoints for liveness and readiness probes. access_log is off for
them so frequent health-check polls do not flood the logs.
