### PR TITLE
Roll release pointer to ce532d9

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: 529a67a
+  sha: ce532d9


### PR DESCRIPTION
Deploy the new health endpoints: the published deployment now tracks ce532d9 (/healthz and /readyz).