### PR TITLE
Track f1bc04b (health checks on /readyz, /healthz; nginx preStop drain)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -2,4 +2,4 @@
 # Changes to this file intentionally do not trigger image builds.
 release:
   branch: main
-  sha: ce532d9
+  sha: f1bc04b


### PR DESCRIPTION
Advances the release pointer to f1bc04b (#286), moving the readiness probe and the load balancer health check onto /readyz, liveness onto /healthz, and adding the nginx preStop drain. Phase 2 cutover.