### PR TITLE
nginx: structured JSON access logs; drop LB health-check noise

### DIFF
--- a/server/nginx.conf
+++ b/server/nginx.conf
@@ -15,11 +15,36 @@ http {
     # Hide the nginx version (and the exact patch version) from the Server header.
     server_tokens off;
 
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent"';
+    # Structured JSON access log (parseable level/message fields for log aggregation). The previous
+    # CLF format showed up as unparsed raw text with no level in log tooling. escape=json safely
+    # escapes user-controlled values (request line, user-agent). level is derived from the status
+    # code (4xx→warning, 5xx→error) so failed requests surface as such; msg = the request line.
+    map $status $access_level {
+        "~^5"   error;
+        "~^4"   warning;
+        default info;
+    }
+    # Drop the load-balancer health-check poll (ELB-HealthChecker hits /wallets-v2.json every few
+    # seconds → constant 200 noise). Same intent as `access_log off` on /healthz below; that one only
+    # catches the dedicated probe path, this one catches the health check that rides the content path.
+    map $http_user_agent $access_loggable {
+        "~ELB-HealthChecker"  0;
+        default               1;
+    }
+    log_format json_access escape=json
+        '{'
+        '"level":"$access_level",'
+        '"msg":"$request",'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"referer":"$http_referer",'
+        '"user_agent":"$http_user_agent"'
+        '}';
 
-    access_log /dev/stdout main;
+    access_log /dev/stdout json_access if=$access_loggable;
 
     server {
         listen 80;


### PR DESCRIPTION
Switch the nginx access log from CLF to structured JSON (`escape=json`) so access logs carry parseable `level`/`msg` fields for log aggregation.

- `level` is derived from the status code: `4xx→warning`, `5xx→error`, else `info`.
- `msg` = the request line.
- Skip the load-balancer health-check poll (`ELB-HealthChecker` hits `/wallets-v2.json` every few seconds → constant 200 noise), matching the existing `access_log off` on the `/healthz` probe path.

Verified in `nginx:alpine`: `nginx -t` clean; 200→`level=info`, 404→`level=warning`; health-check user-agent produces no log line. No test changes (tests do not assert log format).