### PR TITLE
docs: fix stale version.yaml pointer comment

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -1,5 +1,6 @@
 # Release pointer: the published deployment tracks exactly this commit.
-# Changes to this file intentionally do not trigger image builds.
+# build.yml builds a per-sha image for every commit on main, so bumping this
+# pointer also publishes its own image — no separate re-tag step is needed.
 release:
   branch: main
   sha: 0d8c3a8


### PR DESCRIPTION
Комментарий «Changes to this file intentionally do not trigger image builds» устарел: `paths-ignore` убрали в #269 («per-sha builds»). Сейчас `build.yml` не имеет path-фильтра и собирает образ на **каждый** коммит `main`, включая pointer-бамп — у HEAD всегда есть образ, поэтому staging-stranding здесь невозможен и отдельный re-tag не нужен.

Меняется только текст комментария; `release.branch`/`release.sha` не тронуты (verify-release-pointer остаётся зелёным).