### PR TITLE
Release dd8a955

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -3,4 +3,4 @@
 # pointer also publishes its own image — no separate re-tag step is needed.
 release:
   branch: main
-  sha: 0d8c3a8
+  sha: dd8a955


### PR DESCRIPTION
Rolls the release pointer from `0d8c3a8` to `dd8a955`.

Bron (#245) was merged to `main` on 2026-07-07, but the pointer stayed on `0d8c3a8`, so the published `wallets-v2.json` still serves the list without it. 
