### PR TITLE
Add 'chrome' and 'firefox' to supported platforms | SociaWallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -918,7 +918,7 @@
       "url": "https://connect.ton.org/bridge"
     }
   ],
-  "platforms": ["ios", "android", "macos", "windows", "linux"],
+  "platforms": ["ios", "android", "macos", "windows", "linux", "chrome", "firefox"],
   "features": [
     {
       "name": "SendTransaction",


### PR DESCRIPTION
# Add 'chrome' and 'firefox' to supported platforms | SociaWallet