### PR TITLE
Track a45d17f (SociaWallet platforms; cache TTL 5m)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -3,4 +3,4 @@
 # pointer also publishes its own image — no separate re-tag step is needed.
 release:
   branch: main
-  sha: b7166c9
+  sha: a45d17f


### PR DESCRIPTION
Release pointer moves from b7166c9 to a45d17f.

Picks up #304 (chrome and firefox added to SociaWallet platforms) and #305 (max-age on the static location reduced to 300).